### PR TITLE
Python iconv

### DIFF
--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -314,7 +314,6 @@ class Python(Package):
         depends_on("gettext +libxml2", when="+libxml2")
         depends_on("iconv", when="~libxml2")
         depends_on("gettext ~libxml2", when="~libxml2 ^gettext")
-￼
         # Optional dependencies
         # See detect_modules() in setup.py for details
         depends_on("readline", when="+readline")

--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -269,7 +269,7 @@ class Python(Package):
     extendable = True
 
     # Variants to avoid cyclical dependencies for concretizer
-    variant("libxml2", default=False, description="Use a gettext library build with libxml2")
+    variant("libxml2", default=True, description="Use a gettext library build with libxml2")
 
     variant(
         "debug", default=False, description="debug build with extra checks (this is high overhead)"

--- a/repos/spack_repo/builtin/packages/python/package.py
+++ b/repos/spack_repo/builtin/packages/python/package.py
@@ -269,7 +269,7 @@ class Python(Package):
     extendable = True
 
     # Variants to avoid cyclical dependencies for concretizer
-    variant("libxml2", default=True, description="Use a gettext library build with libxml2")
+    variant("libxml2", default=False, description="Use a gettext library build with libxml2")
 
     variant(
         "debug", default=False, description="debug build with extra checks (this is high overhead)"
@@ -312,8 +312,9 @@ class Python(Package):
         depends_on("gmake", type="build")
         depends_on("pkgconfig@0.9.0:", type="build")
         depends_on("gettext +libxml2", when="+libxml2")
-        depends_on("gettext ~libxml2", when="~libxml2")
-
+        depends_on("iconv", when="~libxml2")
+        depends_on("gettext ~libxml2", when="~libxml2 ^gettext")
+￼
         # Optional dependencies
         # See detect_modules() in setup.py for details
         depends_on("readline", when="+readline")


### PR DESCRIPTION
Fix python recipe w.r.t. gettext vs iconv per old upstream PR, and also make it default the way we like it. 