### PR TITLE
log4cplus needed a depends_on("c") to compile in my testing

### DIFF
--- a/repos/spack_repo/builtin/packages/log4cplus/package.py
+++ b/repos/spack_repo/builtin/packages/log4cplus/package.py
@@ -22,3 +22,4 @@ class Log4cplus(CMakePackage):
     version("1.2.1", sha256="ada80be050033d7636beb894eb54de5575ceca95a5572e9437b0fc4ed7d877c4")
 
     depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
